### PR TITLE
Use `wp_json_encode()` to safely render text inside `script` tag

### DIFF
--- a/inc/classes/class-preview-revisions.php
+++ b/inc/classes/class-preview-revisions.php
@@ -65,7 +65,7 @@ class Preview_Revisions {
 
 				let button = document.createElement( 'a' );
 				button.setAttribute( 'class', 'button restore-revision' );
-				button.innerText = '<?php esc_html_e( 'Preview', 'preview-revisions' ); ?>';
+				button.innerText = <?php echo wp_json_encode( __( 'Preview', 'preview-revisions' ); ?>;
 				let appendDoc = document.querySelectorAll( '.revisions-meta .diff-meta-to' );
 
 
@@ -77,7 +77,7 @@ class Preview_Revisions {
 						revId = searchParams.get( 'revision' );
 					}
 
-					let preview_link = '<?php echo esc_url_raw( $preview_link ); ?>' + '&p=' + revId;
+					let preview_link = <?php echo wp_json_encode( esc_url_raw( $preview_link ) ); ?> + '&p=' + revId;
 					button.setAttribute( 'href', preview_link );
 					appendDoc[0].appendChild( button );
 				};

--- a/inc/classes/class-preview-revisions.php
+++ b/inc/classes/class-preview-revisions.php
@@ -65,7 +65,7 @@ class Preview_Revisions {
 
 				let button = document.createElement( 'a' );
 				button.setAttribute( 'class', 'button restore-revision' );
-				button.innerText = <?php echo wp_json_encode( __( 'Preview', 'preview-revisions' ); ?>;
+				button.innerText = <?php echo wp_json_encode( __( 'Preview', 'preview-revisions' ) ); ?>;
 				let appendDoc = document.querySelectorAll( '.revisions-meta .diff-meta-to' );
 
 


### PR DESCRIPTION
Given this existing code:

```php
button.innerText = '<?php esc_html_e( 'Preview', 'preview-revisions' ); ?>';
```

It could be that a translation string incorporates an apostrophe, either because the language uses apostrophes:

> ![image](https://user-images.githubusercontent.com/134745/223208108-bb20f18c-eef5-495b-a68d-a7e53a793048.png)

Which would result in a syntax error here:

```js
button.innerText = 'mua'i va'aiga';
// --------------------^
```

Or it could be that someone is maliciously adding apostrophes to attempt a translation string injection attack.

This is addressed by using `wp_json_encode()` when rendering text inside of `script` tag. 

Issue - #2 