### PR TITLE
Fix return type of modify_posts_request

### DIFF
--- a/inc/classes/class-preview-revisions.php
+++ b/inc/classes/class-preview-revisions.php
@@ -92,7 +92,7 @@ class Preview_Revisions {
 	 * Function to modify the post request.
 	 *
 	 * @param string $posts_request
-	 * @return void
+	 * @return string
 	 */
 	public function modify_posts_request( $posts_request ) {
 


### PR DESCRIPTION
@westonruter Just that.
Discovered by [PHPStan](https://github.com/szepeviktor/phpstan-wordpress).
