### PR TITLE
Version Update v1.5

### DIFF
--- a/preview-revisions.php
+++ b/preview-revisions.php
@@ -7,7 +7,7 @@
  * Author URI:  https://rtcamp.com
  * License:     GPL2
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
- * Version:     1.4
+ * Version:     1.5
  * Text Domain: preview-revisions
  *
  * @package preview-revisions


### PR DESCRIPTION
This is continuation of: https://github.com/rtCamp/wordpress-preview-revisions/pull/6

# Version Update for the rtsocial Plugin :arrow_double_up: 

Current Version: 1.4
Updating Version: 1.5

Updates to compatibility checks as mentioned below

Following is the changelog :spiral_notepad: from the previous version

## Changes
   
* Plugin tested up to WordPress 6.4.2
* PHP Version updated to 8.0
* Fixed PHP Coding Standards issues
* Plugin is VIP compatible
